### PR TITLE
fixes cmake export bug VAN-100

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ endif()
 
 ### Project files
 
-set(Y2L_EXPORT_TARGETS ${PROJECT_NAME}Targets)
 set(DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doc")
 
 # include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/KSIRMacros.cmake)
@@ -93,11 +92,11 @@ add_custom_target(check
 
 ### Install
 
-export(EXPORT ${Y2L_EXPORT_TARGETS}
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/${Y2L_EXPORT_TARGETS}.cmake
+export(EXPORT Yul2LLVMTargets
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/Yul2LLVMTargets.cmake
   NAMESPACE Yul2LLVM::
 )
-install(EXPORT ${Y2L_EXPORT_TARGETS}
+install(EXPORT Yul2LLVMTargets
   NAMESPACE Yul2LLVM::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 

--- a/cmake/Yul2LLVMConfig.cmake.in
+++ b/cmake/Yul2LLVMConfig.cmake.in
@@ -4,5 +4,5 @@ include(CMakeFindDependencyMacro)
 find_dependency(LLVM)
 find_dependency(MLIR)
 
-include("${CMAKE_CURRENT_LIST_DIR}/@KSIR_EXPORT_TARGETS@.cmake")
-check_required_components(@KSIR_EXPORT_TARGETS@)
+include("${CMAKE_CURRENT_LIST_DIR}/@Y2L_EXPORT_TARGETS@.cmake")
+check_required_components(@Y2L_EXPORT_TARGETS@)

--- a/cmake/Yul2LLVMConfig.cmake.in
+++ b/cmake/Yul2LLVMConfig.cmake.in
@@ -4,5 +4,5 @@ include(CMakeFindDependencyMacro)
 find_dependency(LLVM)
 find_dependency(MLIR)
 
-include("${CMAKE_CURRENT_LIST_DIR}/@Y2L_EXPORT_TARGETS@.cmake")
-check_required_components(@Y2L_EXPORT_TARGETS@)
+include("${CMAKE_CURRENT_LIST_DIR}/Yul2LLVMTargets.cmake")
+check_required_components(Yul2LLVMTargets)

--- a/lib/yul2llvm_cpp/CMakeLists.txt
+++ b/lib/yul2llvm_cpp/CMakeLists.txt
@@ -3,6 +3,6 @@ target_link_libraries(yul2llvm_cpp PRIVATE LLVMSupport libyul2llvm)
 set_target_properties(yul2llvm_cpp PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 install(TARGETS yul2llvm_cpp
-  EXPORT ${Y2L_EXPORT_TARGETS}
+  EXPORT Yul2LLVMTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )


### PR DESCRIPTION
CMake used to crash when importing yul2llvm in other CMake projects. 
This PR fixes the issue