### PR TITLE
install and exports libYulAST target and its headers (#55)

### DIFF
--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
@@ -332,7 +332,7 @@ void YulIntrinsicHelper::rewriteStorageOffsetUpdateIntrinsic(
     llvm::Type *destType = getTypeByTypeName(destTypeName);
     llvm::Constant *offsetConst = llvm::ConstantInt::get(
         llvm::Type::getInt32Ty(visitor.getContext()), offset, 10);
-    rewriteUpdateStorageByLocation(callInst, callInst->getArgOperand(0),
+    rewriteUpdateStorageByLocation(callInst, callInst->getArgOperand(1),
                                    offsetConst, destType, storeValue);
   }
 }


### PR DESCRIPTION
Fixes a bug in storage write where wrong argument was being passed to storageUpdateByLocation