### PR TITLE
Bugfix storage pointer addressspace. 

### DIFF
--- a/lib/include/libyul2llvm/YulASTVisitor/CodegenConstants.h
+++ b/lib/include/libyul2llvm/YulASTVisitor/CodegenConstants.h
@@ -1,4 +1,5 @@
 #include <cstdint>
+const uint8_t DEFAULT_ADDR_SPACE = 0;
 const uint8_t STORAGE_ADDR_SPACE = 1;
 const uint8_t MEMORY_ADDR_SPACE = 2;
 const int SLOT_SIZE = 256;

--- a/lib/include/libyul2llvm/YulASTVisitor/CodegenVisitor.h
+++ b/lib/include/libyul2llvm/YulASTVisitor/CodegenVisitor.h
@@ -36,7 +36,8 @@ protected:
   llvm::Value *ptrSelfPointer;
 
   llvm::Type *getTypeByInfo(llvm::StringRef typeStr,
-                            std::map<std::string, TypeInfo> &typeInfoMap);
+                            std::map<std::string, TypeInfo> &typeInfoMap, 
+                            int addrSpaceId);
   void constructSelfStructType(YulContractNode &node);
 
   // external call context

--- a/lib/include/libyul2llvm/YulASTVisitor/IntrinsicHelper.h
+++ b/lib/include/libyul2llvm/YulASTVisitor/IntrinsicHelper.h
@@ -34,7 +34,7 @@ public:
   llvm::Value *getPointerToStorageVarByName(std::string,
                                             llvm::Instruction *insertPoint);
   llvm::StringRef getStorageVarYulTypeByName(llvm::StringRef name);
-  llvm::Type *getTypeByTypeName(llvm::StringRef type, int addrSpaceId=0);
+  llvm::Type *getTypeByTypeName(llvm::StringRef type, const int addrSpaceId);
   llvm::Function *getOrCreateFunction(std::string, llvm::FunctionType *);
   YulIntrinsicHelper(LLVMCodegenVisitor &v);
   llvm::Type *getReturnType(llvm::StringRef);

--- a/lib/include/libyul2llvm/YulASTVisitor/IntrinsicHelper.h
+++ b/lib/include/libyul2llvm/YulASTVisitor/IntrinsicHelper.h
@@ -34,7 +34,7 @@ public:
   llvm::Value *getPointerToStorageVarByName(std::string,
                                             llvm::Instruction *insertPoint);
   llvm::StringRef getStorageVarYulTypeByName(llvm::StringRef name);
-  llvm::Type *getTypeByTypeName(llvm::StringRef type);
+  llvm::Type *getTypeByTypeName(llvm::StringRef type, int addrSpaceId=0);
   llvm::Function *getOrCreateFunction(std::string, llvm::FunctionType *);
   YulIntrinsicHelper(LLVMCodegenVisitor &v);
   llvm::Type *getReturnType(llvm::StringRef);

--- a/lib/libyul2llvm/YulASTVisitor/CallGenHelpers.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/CallGenHelpers.cpp
@@ -145,7 +145,7 @@ llvm::Type *getExtCallReturnType(llvm::CallInst *callInst,
     while (std::regex_search(typesStr, typeMatch, typesRegex)) {
       if (typeMatch[2].matched) {
         std::string type = typeMatch[2].str();
-        retType = v.getYulIntrisicHelper().getTypeByTypeName(type);
+        retType = v.getYulIntrisicHelper().getTypeByTypeName(type, DEFAULT_ADDR_SPACE);
       } else if (typeMatch[3].matched || typeMatch[4].matched) {
         //@todo raise runtime error
         assert(false && "unhandled return types from external calls");

--- a/lib/libyul2llvm/YulASTVisitor/CodegenVisitor.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/CodegenVisitor.cpp
@@ -383,7 +383,7 @@ void LLVMCodegenVisitor::constructSelfStructType(YulContractNode &node) {
   auto &typeInfoMap = node.getTypeInfoMap();
   for (auto &field : node.getStructFieldOrder()) {
     std::string typeStr = node.getVarTypeMap()[field].type;
-    llvm::Type *type = getTypeByInfo(typeStr, typeInfoMap);
+    llvm::Type *type = getTypeByInfo(typeStr, typeInfoMap, STORAGE_ADDR_SPACE);
     memberTypes.push_back(type);
   }
 
@@ -393,8 +393,8 @@ void LLVMCodegenVisitor::constructSelfStructType(YulContractNode &node) {
 }
 
 llvm::Type *LLVMCodegenVisitor::getTypeByInfo(
-    llvm::StringRef typeStr, std::map<std::string, TypeInfo> &typeInfoMap) {
-  llvm::Type *memPtrType = llvm::Type::getIntNPtrTy(*TheContext, 256);
+    llvm::StringRef typeStr, std::map<std::string, TypeInfo> &typeInfoMap, int addrSpaceId) {
+  llvm::Type *memPtrType = llvm::Type::getIntNPtrTy(*TheContext, 256, addrSpaceId);
   if (typeStr.startswith("t_mapping")) {
     return memPtrType;
   } else if (typeStr.find("t_array") != typeStr.npos) {

--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicEmitter.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicEmitter.cpp
@@ -224,7 +224,7 @@ YulIntrinsicHelper::handleReadFromMemory(YulFunctionCallNode &node) {
     std::string type = match[1].str();
     llvm::Value *pointer = visitor.visit(*node.getArgs()[0]);
     auto &builder = visitor.getBuilder();
-    llvm::Type *loadType = getTypeByTypeName(type);
+    llvm::Type *loadType = getTypeByTypeName(type, DEFAULT_ADDR_SPACE);
     llvm::Value *loadedWord = builder.CreateLoad(loadType, pointer, "arr_load");
     return builder.CreateIntCast(loadedWord, visitor.getDefaultType(), false,
                                  "word_" + loadedWord->getName());
@@ -244,7 +244,7 @@ YulIntrinsicHelper::handleWriteToMemory(YulFunctionCallNode &node) {
     std::string type = match[1].str();
     llvm::Value *pointer = visitor.visit(*node.getArgs()[0]);
     llvm::Value *valueToStore = visitor.visit(*node.getArgs()[1]);
-    llvm::Type *elementType = getTypeByTypeName(type);
+    llvm::Type *elementType = getTypeByTypeName(type, DEFAULT_ADDR_SPACE);
     if (valueToStore->getType()->isPointerTy()) {
       valueToStore = builder.CreatePtrToInt(valueToStore, elementType);
     } else {
@@ -284,7 +284,7 @@ YulIntrinsicHelper::handleMemoryArrayIndexAccess(YulFunctionCallNode &node) {
     //@todo raise runtime error
     assert(false && "memory_array_index did not match regex");
   }
-  llvm::Type *elementType = getTypeByTypeName(elementTypeName);
+  llvm::Type *elementType = getTypeByTypeName(elementTypeName, DEFAULT_ADDR_SPACE);
   llvm::ArrayType *arrayType = llvm::ArrayType::get(elementType, 0);
   llvm::Value *array = visitor.visit(*node.getArgs()[0]);
   llvm::Value *idx = visitor.visit(*node.getArgs()[1]);

--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicHelper.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicHelper.cpp
@@ -44,7 +44,7 @@ llvm::Value *YulIntrinsicHelper::getPointerToStorageVarByName(
   return ptr;
 }
 
-llvm::Type *YulIntrinsicHelper::getTypeByTypeName(llvm::StringRef type) {
+llvm::Type *YulIntrinsicHelper::getTypeByTypeName(llvm::StringRef type, int addrSpaceId) {
   auto &typeInfoMap = visitor.currentContract->getTypeInfoMap();
   std::regex uintTypeRegex(R"(^t_uint(\d+)$)");
   std::regex bytesTypeRegex(R"(^t_bytes(\d+)$)");
@@ -65,7 +65,7 @@ llvm::Type *YulIntrinsicHelper::getTypeByTypeName(llvm::StringRef type) {
     }
     bitWidth = bitWidth * 8;
   } else if (type.startswith("t_array")) {
-    return visitor.getDefaultType()->getPointerTo();
+    return visitor.getDefaultType()->getPointerTo(addrSpaceId);
   } else {
     //@todo raise runtime error
     assert(false && "type not found in typeinfomap and could not infer");

--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicHelper.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicHelper.cpp
@@ -44,7 +44,7 @@ llvm::Value *YulIntrinsicHelper::getPointerToStorageVarByName(
   return ptr;
 }
 
-llvm::Type *YulIntrinsicHelper::getTypeByTypeName(llvm::StringRef type, int addrSpaceId) {
+llvm::Type *YulIntrinsicHelper::getTypeByTypeName(llvm::StringRef type, const int addrSpaceId = 0) {
   auto &typeInfoMap = visitor.currentContract->getTypeInfoMap();
   std::regex uintTypeRegex(R"(^t_uint(\d+)$)");
   std::regex bytesTypeRegex(R"(^t_bytes(\d+)$)");

--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
@@ -87,7 +87,7 @@ void YulIntrinsicHelper::rewriteCallIntrinsic(llvm::CallInst *callInst) {
 void YulIntrinsicHelper::rewriteMapIndexCalls(llvm::CallInst *callInst) {
   llvm::SmallVector<llvm::Type *> argTypes;
   auto tmpBuilder = llvm::IRBuilder<>(callInst);
-  llvm::Type *retType = llvm::Type::getIntNPtrTy(visitor.getContext(), 256);
+  llvm::Type *retType = llvm::Type::getIntNPtrTy(visitor.getContext(), 256, STORAGE_ADDR_SPACE);
   argTypes.push_back(retType);
   argTypes.push_back(llvm::Type::getIntNTy(visitor.getContext(), 256));
   llvm::FunctionType *FT = llvm::FunctionType::get(retType, argTypes, false);

--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
@@ -357,7 +357,7 @@ void YulIntrinsicHelper::rewriteStorageArrayIndexAccess(
     //@todo raise runtime error
     assert(false && "could not parse array size");
   }
-  llvm::Type *elementType = getTypeByTypeName(elementTypeName);
+  llvm::Type *elementType = getTypeByTypeName(elementTypeName, STORAGE_ADDR_SPACE);
   llvm::Value *slot = callInst->getArgOperand(1);
   llvm::Value *index = callInst->getArgOperand(2);
   assert(index->getType()->isIntegerTy() && "index is not int type");
@@ -381,20 +381,20 @@ void YulIntrinsicHelper::rewriteStorageArrayIndexAccess(
   } else {
     if (slot->getType()->isPointerTy())
       arrayPtr = builder.CreatePointerCast(
-          slot, visitor.getDefaultType()->getPointerTo(),
+          slot, visitor.getDefaultType()->getPointerTo(STORAGE_ADDR_SPACE),
           slot->getName() + "_casted");
     else
       arrayPtr =
-          builder.CreateIntToPtr(slot, visitor.getDefaultType()->getPointerTo(),
+          builder.CreateIntToPtr(slot, visitor.getDefaultType()->getPointerTo(STORAGE_ADDR_SPACE),
                                  slot->getName() + "_casted");
   }
   llvm::Value *zero = llvm::ConstantInt::get(
       llvm::Type::getInt32Ty(visitor.getContext()), 0, 10);
-  arrayPtr = builder.CreateLoad(visitor.getDefaultType()->getPointerTo(),
+  arrayPtr = builder.CreateLoad(visitor.getDefaultType()->getPointerTo(STORAGE_ADDR_SPACE),
                                 arrayPtr, arrayPtr->getName().drop_front(4));
   llvm::Type *arrayType = llvm::ArrayType::get(elementType, 0);
   auto castedArrayPtr =
-      builder.CreatePointerCast(arrayPtr, arrayType->getPointerTo());
+      builder.CreatePointerCast(arrayPtr, arrayType->getPointerTo(STORAGE_ADDR_SPACE));
   llvm::Value *elementPtr =
       builder.CreateGEP(arrayType, castedArrayPtr, {zero, truncIndex},
                         "ptr_" + arrayPtr->getName() + "[" + indexString + "]");

--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
@@ -209,7 +209,7 @@ void YulIntrinsicHelper::rewriteStorageDynamicLoadIntrinsic(
   } else {
     rewriteLoadStorageByLocation(callInst, callInst->getArgOperand(0),
                                  callInst->getArgOperand(1),
-                                 getTypeByTypeName(yulTypeStr));
+                                 getTypeByTypeName(yulTypeStr, DEFAULT_ADDR_SPACE));
   }
 }
 
@@ -235,7 +235,7 @@ void YulIntrinsicHelper::rewriteStorageOffsetLoadIntrinsic(
         visitor.currentContract->getStateVarNameBySlotOffset(slot, offset);
     rewriteLoadStorageVarByName(callInst, varname);
   } else {
-    llvm::Type *loadType = getTypeByTypeName(yulTypeStr);
+    llvm::Type *loadType = getTypeByTypeName(yulTypeStr, DEFAULT_ADDR_SPACE);
     llvm::Constant *offsetConst =
         llvm::ConstantInt::get(visitor.getDefaultType(), offset, 10);
     rewriteLoadStorageByLocation(callInst, callInst->getArgOperand(0),
@@ -296,7 +296,7 @@ void YulIntrinsicHelper::rewriteStorageDynamicUpdateIntrinsic(
         slotConst->getZExtValue(), offsetConst->getZExtValue());
     rewriteUpdateStorageVarByName(callInst, varname, storeValue);
   } else {
-    llvm::Type *destType = getTypeByTypeName(destTypeName);
+    llvm::Type *destType = getTypeByTypeName(destTypeName, DEFAULT_ADDR_SPACE);
     llvm::Value *offsetIndex = tempBuilder.CreateIntCast(
         offsetArg, llvm::Type::getInt32Ty(visitor.getContext()), false,
         "array_offset");
@@ -329,7 +329,7 @@ void YulIntrinsicHelper::rewriteStorageOffsetUpdateIntrinsic(
         slot->getZExtValue(), offset);
     rewriteUpdateStorageVarByName(callInst, varname, storeValue);
   } else {
-    llvm::Type *destType = getTypeByTypeName(destTypeName);
+    llvm::Type *destType = getTypeByTypeName(destTypeName, DEFAULT_ADDR_SPACE);
     llvm::Constant *offsetConst = llvm::ConstantInt::get(
         llvm::Type::getInt32Ty(visitor.getContext()), offset, 10);
     rewriteUpdateStorageByLocation(callInst, callInst->getArgOperand(1),

--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
@@ -332,7 +332,7 @@ void YulIntrinsicHelper::rewriteStorageOffsetUpdateIntrinsic(
     llvm::Type *destType = getTypeByTypeName(destTypeName);
     llvm::Constant *offsetConst = llvm::ConstantInt::get(
         llvm::Type::getInt32Ty(visitor.getContext()), offset, 10);
-    rewriteUpdateStorageByLocation(callInst, callInst->getArgOperand(0),
+    rewriteUpdateStorageByLocation(callInst, callInst->getArgOperand(1),
                                    offsetConst, destType, storeValue);
   }
 }

--- a/tests/e2e/feature/mapping.sol
+++ b/tests/e2e/feature/mapping.sol
@@ -17,10 +17,10 @@ contract MappingTestCase {
 }
 
 //CHECK: {{define i256 @fun_mappingRead_[0-9]+\(i256 addrspace\(1\)\* \%__self.*\)}}
-//CHECK: {{call i256\* @pyul_map_index\(i256\* \%.+, .+\)}}
+//CHECK: {{call i256 addrspace\(1\)\* @pyul_map_index\(i256 addrspace\(1\)\* \%.+, .+\)}}
 //CHECK: {{load i256, i256\*}}
 
 
 //CHECK: {{define void @fun_mappingWrite_[0-9]+\(i256 addrspace\(1\)\* \%__self.*, .+, .+\)}}
-//CHECK: {{call i256\* @pyul_map_index\(i256\* \%.+, .+\)}}
+//CHECK: {{call i256 addrspace\(1\)\* @pyul_map_index\(i256 addrspace\(1\)\* \%.+, .+\)}}
 //CHECK: {{store i256 .+, i256\*.*}}

--- a/tests/e2e/feature/nested-mapping.sol
+++ b/tests/e2e/feature/nested-mapping.sol
@@ -17,12 +17,12 @@ contract NestedMappingTestCase {
 }
 
 //CHECK: define i256 @fun_mappingRead_{{[0-9]+\(i256 addrspace\(1\)\* \%__self, .+, .+\)}}
-//CHECK: call i256* @pyul_map_index{{\(i256\* \%.+, .+\)}}
-//CHECK: call i256* @pyul_map_index{{\(i256\* \%.+, .+\)}}
+//CHECK: call i256 addrspace(1)* @pyul_map_index{{\(i256 addrspace\(1\)\* \%.+, .+\)}}
+//CHECK: call i256 addrspace(1)* @pyul_map_index{{\(i256 addrspace\(1\)\* \%.+, .+\)}}
 //CHECK: load i32, i32*
 
 
 //CHECK: define void @fun_mappingWrite_{{[0-9]+\(i256 addrspace\(1\)\* \%__self, .+, .+, .+\)}}
-//CHECK: call i256* @pyul_map_index({{i256\* \%.+, .+}})
-//CHECK: call i256* @pyul_map_index({{i256\* \%.+, .+}})
+//CHECK: call i256 addrspace(1)* @pyul_map_index({{i256 addrspace\(1\)\* \%.+, .+}})
+//CHECK: call i256 addrspace(1)* @pyul_map_index({{i256 addrspace\(1\)\* \%.+, .+}})
 //CHECK: store i32 {{.+}}, i32*

--- a/tests/e2e/feature/storage/array-storage.sol
+++ b/tests/e2e/feature/storage/array-storage.sol
@@ -29,20 +29,20 @@ contract ArrayTest {
 //CHECK: %{{.*}} = trunc i256 %{{.*}} to i32
 //CHECK: %{{.*}} = getelementptr %{{.*}}, %{{.*}}, i32 {{.*}}
 //CHECK: %{{.*}} = load i256 addrspace(1)*, i256 addrspace(1)* addrspace(1)* %{{.*}}, align 8
-//CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}*]*
-//CHECK: getelementptr [0 x {{.*}}], [0 x {{.*}}*]* %{{.*}}, i32 0, i32 %{{.*}}
-//CHECK: {{(bitcast)|(inttoptr)}} {{.*}} %{{.*}} to i256* 
-//CHECK: %{{.*}} = load i256 addrspace(1)*, i256* %{{.*}}, align 8
-//CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}]*
-//CHECK: getelementptr [0 x {{.*}}], [0 x {{.*}}]* %{{.*}}, i32 0, i32 {{.*}}
+//CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}*] addrspace(1)*
+//CHECK: getelementptr [0 x {{.*}}], [0 x {{.*}}*] addrspace(1)* %{{.*}}, i32 0, i32 %{{.*}}
+//CHECK: {{(bitcast)|(inttoptr)}} {{.*}} %{{.*}} to i256 addrspace(1)* 
+//CHECK: %{{.*}} = load i256 addrspace(1)*, i256 addrspace(1)* %{{.*}}, align 8
+//CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}] addrspace(1)*
+//CHECK: getelementptr [0 x {{.*}}], [0 x {{.*}}] addrspace(1)* %{{.*}}, i32 0, i32 {{.*}}
 //CHECK: ret i256 %read_from_storage_split_dynamic_t_uint32 
 
 //CHECK: define void @fun_writeArray_{{.*}}(i256 addrspace(1)* %{{.*}}, {{.*}} %{{.*}}, {{.*}} %{{.*}}) 
 //CHECK: %{{.*}} = trunc i256 %{{.*}} to i32
 //CHECK: %{{.*}} = getelementptr %{{.*}}, %{{.*}}* %0, i32 {{.*}}
 //CHECK: %{{.*}} = load i256 addrspace(1)*, i256 addrspace(1)* addrspace(1)* %{{.*}}, align 8
-//CHECK: %1 = bitcast {{.*}}* %{{.*}} to [0 x {{.*}}*]*
-//CHECK: %"{{.*}}[{{.*}}]" = getelementptr [0 x {{.*}}*], [0 x {{.*}}*]* %{{.*}}, i32 0, i32 %{{.*}}
-//CHECK: %{{.*}} = load i256 addrspace(1)*, i256* %{{.*}}, align 8
-//CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}]*
-//CHECK: %"{{.*}}[{{.*}}]" = getelementptr [0 x {{.*}}], [0 x {{.*}}]* %{{.*}}, i32 0, i32 {{.*}}
+//CHECK: %1 = bitcast {{.*}}* %{{.*}} to [0 x {{.*}}*] addrspace(1)*
+//CHECK: %"{{.*}}[{{.*}}]" = getelementptr [0 x {{.*}} addrspace(1)*], [0 x {{.*}} addrspace(1)*] addrspace(1)* %{{.*}}, i32 0, i32 %{{.*}}
+//CHECK: %{{.*}} = load i256 addrspace(1)*, i256 addrspace(1)* %{{.*}}, align 8
+//CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}] addrspace(1)*
+//CHECK: %"{{.*}}[{{.*}}]" = getelementptr [0 x {{.*}}], [0 x {{.*}}] addrspace(1)* %{{.*}}, i32 0, i32 {{.*}}

--- a/tests/e2e/feature/storage/array-storage.sol
+++ b/tests/e2e/feature/storage/array-storage.sol
@@ -28,11 +28,11 @@ contract ArrayTest {
 //CHECK: define i256 @fun_readArray_25(i256 addrspace(1)* %__self, i256 %var_index_13)
 //CHECK: %{{.*}} = trunc i256 %{{.*}} to i32
 //CHECK: %{{.*}} = getelementptr %{{.*}}, %{{.*}}, i32 {{.*}}
-//CHECK: %{{.*}} = load i256*, i256* addrspace(1)* %{{.*}}, align 8
+//CHECK: %{{.*}} = load i256 addrspace(1)*, i256 addrspace(1)* addrspace(1)* %{{.*}}, align 8
 //CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}*]*
 //CHECK: getelementptr [0 x {{.*}}], [0 x {{.*}}*]* %{{.*}}, i32 0, i32 %{{.*}}
 //CHECK: {{(bitcast)|(inttoptr)}} {{.*}} %{{.*}} to i256* 
-//CHECK: %{{.*}} = load i256*, i256* %{{.*}}, align 8
+//CHECK: %{{.*}} = load i256 addrspace(1)*, i256* %{{.*}}, align 8
 //CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}]*
 //CHECK: getelementptr [0 x {{.*}}], [0 x {{.*}}]* %{{.*}}, i32 0, i32 {{.*}}
 //CHECK: ret i256 %read_from_storage_split_dynamic_t_uint32 
@@ -40,9 +40,9 @@ contract ArrayTest {
 //CHECK: define void @fun_writeArray_{{.*}}(i256 addrspace(1)* %{{.*}}, {{.*}} %{{.*}}, {{.*}} %{{.*}}) 
 //CHECK: %{{.*}} = trunc i256 %{{.*}} to i32
 //CHECK: %{{.*}} = getelementptr %{{.*}}, %{{.*}}* %0, i32 {{.*}}
-//CHECK: %{{.*}} = load i256*, i256* addrspace(1)* %{{.*}}, align 8
+//CHECK: %{{.*}} = load i256 addrspace(1)*, i256 addrspace(1)* addrspace(1)* %{{.*}}, align 8
 //CHECK: %1 = bitcast {{.*}}* %{{.*}} to [0 x {{.*}}*]*
 //CHECK: %"{{.*}}[{{.*}}]" = getelementptr [0 x {{.*}}*], [0 x {{.*}}*]* %{{.*}}, i32 0, i32 %{{.*}}
-//CHECK: %{{.*}} = load i256*, i256* %{{.*}}, align 8
+//CHECK: %{{.*}} = load i256 addrspace(1)*, i256* %{{.*}}, align 8
 //CHECK: bitcast {{.*}}* %{{.*}} to [0 x {{.*}}]*
 //CHECK: %"{{.*}}[{{.*}}]" = getelementptr [0 x {{.*}}], [0 x {{.*}}]* %{{.*}}, i32 0, i32 {{.*}}


### PR DESCRIPTION
Fixed following bug: 
Self struct itself was declared in storage address space but pointers in the self struct were pointing to default addressspace. 