### PR TITLE
Moved regex matching out into its own class and interface

### DIFF
--- a/lib/include/libYulAST/IntrinsicPatterns.h
+++ b/lib/include/libYulAST/IntrinsicPatterns.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <regex>
+#include <libYulAST/YulConstants.h>
+
+namespace yulast{
+class IntrinsicPatternMatcher{
+    std::regex readFromStorageOffsetRegex;
+    std::regex readFromStorageDynamicRegex;
+    std::regex updateStorageOffsetfRegex;
+    std::regex updateStorageDynamicRegex;
+
+    public:
+        IntrinsicPatternMatcher();
+        YUL_INTRINSIC_ID getYulIntriniscType(std::string_view name);
+        int readFromStorageOffsetGetOffset(std::string_view name);
+        std::string readFromStorageOffsetGetType(std::string_view name);
+        std::string readFromStorageDynamicGetType(std::string_view name);
+        
+        int updateStorageOffsetGetOffset(std::string_view name);
+        std::string updateStorageOffsetGetFromType(std::string_view name);
+        std::string updateStorageOffsetGetToType(std::string_view name);
+        std::string updateStorageDynamicGetFromType(std::string_view name);
+        std::string updateStorageDynamicGetToType(std::string_view name);
+};
+}

--- a/lib/include/libYulAST/IntrinsicPatterns.h
+++ b/lib/include/libYulAST/IntrinsicPatterns.h
@@ -3,6 +3,26 @@
 #include <libYulAST/YulConstants.h>
 
 namespace yulast{
+struct ReadFromStorageOffsetResult{
+    std::string type;
+    int offset;
+};
+
+struct ReadFromStorageDynamicResult{
+    std::string type;
+};
+
+struct UpdateStorageOffsetResult{
+    std::string fromType;
+    std::string toType;
+    int offset;
+};
+
+struct UpdateStorageDynamicResult{
+    std::string fromType;
+    std::string toType;
+};
+
 class IntrinsicPatternMatcher{
     std::regex readFromStorageOffsetRegex;
     std::regex readFromStorageDynamicRegex;
@@ -14,12 +34,19 @@ class IntrinsicPatternMatcher{
         YUL_INTRINSIC_ID getYulIntriniscType(std::string_view name);
         int readFromStorageOffsetGetOffset(std::string_view name);
         std::string readFromStorageOffsetGetType(std::string_view name);
+        ReadFromStorageOffsetResult parseReadFromStorageOffset(std::string_view name);
+        
         std::string readFromStorageDynamicGetType(std::string_view name);
+        ReadFromStorageDynamicResult parseReadFromStorageDynamic(std::string_view name);     
         
         int updateStorageOffsetGetOffset(std::string_view name);
         std::string updateStorageOffsetGetFromType(std::string_view name);
         std::string updateStorageOffsetGetToType(std::string_view name);
+        UpdateStorageOffsetResult parseUpdateStorageOffset(std::string_view name);
+
         std::string updateStorageDynamicGetFromType(std::string_view name);
         std::string updateStorageDynamicGetToType(std::string_view name);
+        UpdateStorageDynamicResult parseUpdateStorageDynamic(std::string_view name);
+
 };
 }

--- a/lib/include/libYulAST/YulConstants.h
+++ b/lib/include/libYulAST/YulConstants.h
@@ -1,4 +1,5 @@
 #pragma once
+#include<string>
 #define YUL_STATEMENT_KEY "yul_statement"
 #define YUL_EXPRESSION_KEY "yul_expression"
 #define YUL_IDENTIFIER_KEY "yul_identifier"
@@ -71,9 +72,9 @@ enum class YUL_INTRINSIC_ID{
   INVALID_INTRINSIC_ID
 };
 
-#define READ_FROM_STORAGE_OFFSET_REGEX_LIT R"(^read_from_storage(_split)?_offset_([0-9]+)_(.*)$)"
-#define READ_FROM_STORAGE_DYNAMIC_REGEX_LIT R"(^read_from_storage_split_dynamic_(.*))"
-#define UPDATE_STORAGE_OFFSET_REGEX_LIT R"(^update_storage_value_offset_([0-9]+)(.*)_to_(.*)$)"
-#define UPDATE_STORAGE_DYNAMIC_REGEX_LIT R"(^update_storage_value_(.*)_to_(.*)$)"
+const std::string READ_FROM_STORAGE_OFFSET_REGEX_LIT = R"(^read_from_storage(_split)?_offset_([0-9]+)_(.*)$)";
+const std::string READ_FROM_STORAGE_DYNAMIC_REGEX_LIT = R"(^read_from_storage_split_dynamic_(.*))";
+const std::string UPDATE_STORAGE_OFFSET_REGEX_LIT = R"(^update_storage_value_offset_([0-9]+)(.*)_to_(.*)$)";
+const std::string UPDATE_STORAGE_DYNAMIC_REGEX_LIT = R"(^update_storage_value_(.*)_to_(.*)$)";
 
 }; // namespace yulast

--- a/lib/include/libYulAST/YulConstants.h
+++ b/lib/include/libYulAST/YulConstants.h
@@ -62,4 +62,18 @@ enum class YUL_AST_LITERAL_NODE_TYPE {
   YUL_AST_LITERAL_NUMBER,
   YUL_AST_LITERAL_STRING
 };
+
+enum class YUL_INTRINSIC_ID{
+  READ_FROM_STORAGE_OFFSET,
+  READ_FROM_STORAGE_DYNAMIC,
+  UPDATE_STORAGE_OFFSET, 
+  UPDATE_STORAGE_DYNAMIC, 
+  INVALID_INTRINSIC_ID
+};
+
+#define READ_FROM_STORAGE_OFFSET_REGEX_LIT R"(^read_from_storage(_split)?_offset_([0-9]+)_(.*)$)"
+#define READ_FROM_STORAGE_DYNAMIC_REGEX_LIT R"(^read_from_storage_split_dynamic_(.*))"
+#define UPDATE_STORAGE_OFFSET_REGEX_LIT R"(^update_storage_value_offset_([0-9]+)(.*)_to_(.*)$)"
+#define UPDATE_STORAGE_DYNAMIC_REGEX_LIT R"(^update_storage_value_(.*)_to_(.*)$)"
+
 }; // namespace yulast

--- a/lib/include/libyul2llvm/YulASTVisitor/IntrinsicHelper.h
+++ b/lib/include/libyul2llvm/YulASTVisitor/IntrinsicHelper.h
@@ -8,6 +8,7 @@ class LLVMCodegenVisitor;
 #include <llvm/Transforms/Utils.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 #include <regex>
+#include <libYulAST/IntrinsicPatterns.h>
 
 using namespace yulast;
 class YulIntrinsicHelper {
@@ -23,6 +24,7 @@ class YulIntrinsicHelper {
   llvm::Value *getPointerInSlotByOffset(llvm::CallInst *callInst,
                                         llvm::Value *slot, llvm::Value *offset,
                                         llvm::Type *type);
+  IntrinsicPatternMatcher patternMatcher;
 
 public:
   // Helpers
@@ -65,15 +67,13 @@ public:
   // Rewrites
   void rewriteIntrinsics(llvm::Function *enclosingFunction);
   void rewriteMapIndexCalls(llvm::CallInst *callInst);
-  void rewriteStorageOffsetUpdateIntrinsic(llvm::CallInst *callInst,
-                                           std::smatch &match);
-  void rewriteStorageDynamicUpdateIntrinsic(llvm::CallInst *callInst,
-                                            std::smatch &match);
+  void rewriteStorageOffsetUpdateIntrinsic(llvm::CallInst *callInst, 
+                    int offset, std::string srcTypeName, 
+                    std::string destTypeName);
+  void rewriteStorageDynamicUpdateIntrinsic(llvm::CallInst *callInst, std::string srcTypeName, std::string destTypeName);
   void rewriteStorageUpdateIntrinsic(llvm::CallInst *callInst);
-  void rewriteStorageOffsetLoadIntrinsic(llvm::CallInst *callInst,
-                                         std::smatch &match);
-  void rewriteStorageDynamicLoadIntrinsic(llvm::CallInst *callInst,
-                                          std::smatch &match);
+  void rewriteStorageOffsetLoadIntrinsic(llvm::CallInst *callInst, int offset, std::string yulTypeStr);
+  void rewriteStorageDynamicLoadIntrinsic(llvm::CallInst *callInst, std::string yulTypeStr);
   void rewriteStorageLoadIntrinsic(llvm::CallInst *callInst);
   void rewriteCallIntrinsic(llvm::CallInst *callInst);
   void rewriteStorageArrayIndexAccess(llvm::CallInst *callInst);

--- a/lib/libYulAST/CMakeLists.txt
+++ b/lib/libYulAST/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(libYulAST
   YulForNode.cpp
   YulStringLiteralNode.cpp
   YulContractNode.cpp
+  IntrinsicPatterns.cpp
   )
 
 

--- a/lib/libYulAST/IntrinsicPatterns.cpp
+++ b/lib/libYulAST/IntrinsicPatterns.cpp
@@ -114,4 +114,33 @@ namespace yulast
     return "";
   }
 
+  ReadFromStorageOffsetResult IntrinsicPatternMatcher::parseReadFromStorageOffset(std::string_view name){
+    ReadFromStorageOffsetResult res;
+    res.offset = readFromStorageOffsetGetOffset(name);
+    res.type = readFromStorageOffsetGetType(name);
+    return res;
+  }
+
+  ReadFromStorageDynamicResult IntrinsicPatternMatcher::parseReadFromStorageDynamic(std::string_view name){
+    ReadFromStorageDynamicResult res;
+    res.type = readFromStorageDynamicGetType(name);
+    return res;
+  }
+
+  UpdateStorageOffsetResult IntrinsicPatternMatcher::parseUpdateStorageOffset(std::string_view name){
+    UpdateStorageOffsetResult res;
+    res.offset = updateStorageOffsetGetOffset(name);
+    res.fromType = updateStorageOffsetGetFromType(name);
+    res.toType = updateStorageOffsetGetToType(name);
+    return res;
+  }
+
+  UpdateStorageDynamicResult IntrinsicPatternMatcher::parseUpdateStorageDynamic(std::string_view name){
+    UpdateStorageDynamicResult res;
+    res.fromType = updateStorageDynamicGetFromType(name);
+    res.toType = updateStorageDynamicGetToType(name);
+    return res;
+  }
+
+
 }; // namespace yulast

--- a/lib/libYulAST/IntrinsicPatterns.cpp
+++ b/lib/libYulAST/IntrinsicPatterns.cpp
@@ -1,0 +1,117 @@
+#include <libYulAST/IntrinsicPatterns.h>
+#include <cassert>
+
+namespace yulast
+{
+  IntrinsicPatternMatcher::IntrinsicPatternMatcher() :
+    readFromStorageOffsetRegex(READ_FROM_STORAGE_OFFSET_REGEX_LIT),
+    readFromStorageDynamicRegex(READ_FROM_STORAGE_DYNAMIC_REGEX_LIT),
+    updateStorageOffsetfRegex(UPDATE_STORAGE_OFFSET_REGEX_LIT),
+    updateStorageDynamicRegex(UPDATE_STORAGE_DYNAMIC_REGEX_LIT){
+  }
+
+  YUL_INTRINSIC_ID IntrinsicPatternMatcher::
+                getYulIntriniscType(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, readFromStorageOffsetRegex )){
+        return YUL_INTRINSIC_ID::READ_FROM_STORAGE_OFFSET;
+    } else if(std::regex_match(nameStr, match, readFromStorageDynamicRegex )){
+        return YUL_INTRINSIC_ID::READ_FROM_STORAGE_DYNAMIC;
+    } else if(std::regex_match(nameStr, match, updateStorageOffsetfRegex )){
+        return YUL_INTRINSIC_ID::UPDATE_STORAGE_OFFSET;
+    } else if(std::regex_match(nameStr, match, updateStorageDynamicRegex )){
+        return YUL_INTRINSIC_ID::UPDATE_STORAGE_DYNAMIC;
+    }
+    return YUL_INTRINSIC_ID::INVALID_INTRINSIC_ID;
+  }  
+
+  int IntrinsicPatternMatcher::readFromStorageOffsetGetOffset(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, readFromStorageOffsetRegex)){
+        return std::stoi(match[2].str());
+    } else {
+        assert(false && "Regex did not match");
+    }
+    return 0;
+  }
+
+  std::string IntrinsicPatternMatcher::readFromStorageOffsetGetType(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, readFromStorageOffsetRegex)){
+        return match[3].str();
+    } else {
+        assert(false && "Regex did not match");
+    }
+    return "";
+  }
+
+  std::string IntrinsicPatternMatcher::readFromStorageDynamicGetType(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, readFromStorageDynamicRegex)){
+        return match[1].str();
+    } else {
+        assert(false && "Regex did not match");
+    }
+    return "";
+  }
+
+  int IntrinsicPatternMatcher::updateStorageOffsetGetOffset(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, updateStorageOffsetfRegex)){
+        return std::stoi(match[1].str());
+    } else {
+        assert(false && "Regex did not match");
+    }
+    return 0;
+  }
+
+  std::string IntrinsicPatternMatcher::updateStorageOffsetGetFromType(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, updateStorageOffsetfRegex)){
+        return match[2].str();
+    } else {
+        assert(false && "Regex did not match");
+    }
+    return "";
+  }
+
+  std::string IntrinsicPatternMatcher::updateStorageOffsetGetToType(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, updateStorageOffsetfRegex)){
+        return match[3].str();
+    } else {
+        assert(false && "Regex did not match");
+    }
+    return "";
+  }
+
+  std::string IntrinsicPatternMatcher::updateStorageDynamicGetFromType(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, updateStorageDynamicRegex)){
+        return match[1].str();
+    } else {
+        assert(false && "Regex did not match");
+    }
+    return "";
+  }
+
+  std::string IntrinsicPatternMatcher::updateStorageDynamicGetToType(std::string_view name){
+    std::smatch match;
+    std::string nameStr(name);
+    if(std::regex_match(nameStr, match, updateStorageDynamicRegex)){
+        return match[2].str();
+    } else {
+        assert(false && "Regex did not match");
+    }
+    return "";
+  }
+
+}; // namespace yulast

--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
@@ -235,12 +235,12 @@ void YulIntrinsicHelper::rewriteStorageLoadIntrinsic(llvm::CallInst *callInst) {
   std::string calleeName = callInst->getCalledFunction()->getName().str();
   YUL_INTRINSIC_ID loadType = patternMatcher.getYulIntriniscType(calleeName);
   if (loadType == YUL_INTRINSIC_ID::READ_FROM_STORAGE_OFFSET) {
-    int offset = patternMatcher.readFromStorageOffsetGetOffset(calleeName);
+    auto res = patternMatcher.parseReadFromStorageOffset(calleeName);
     std::string typeStr = patternMatcher.readFromStorageOffsetGetType(calleeName);
-    rewriteStorageOffsetLoadIntrinsic(callInst, offset, typeStr);
+    rewriteStorageOffsetLoadIntrinsic(callInst, res.offset, res.type);
   } else if (loadType == YUL_INTRINSIC_ID::READ_FROM_STORAGE_DYNAMIC) {
-    std::string typeStr = patternMatcher.readFromStorageDynamicGetType(calleeName);
-    rewriteStorageDynamicLoadIntrinsic(callInst, typeStr);
+    auto res = patternMatcher.parseReadFromStorageDynamic(calleeName);
+    rewriteStorageDynamicLoadIntrinsic(callInst, res.type);
   } else {
     //@todo raise runtime error
     assert(false && "unrecognized read from storage dynamic intrinsic");
@@ -252,14 +252,11 @@ void YulIntrinsicHelper::rewriteStorageUpdateIntrinsic(
   std::string calleeName = callInst->getCalledFunction()->getName().str();
   YUL_INTRINSIC_ID updateType = patternMatcher.getYulIntriniscType(calleeName);
   if (updateType == YUL_INTRINSIC_ID::UPDATE_STORAGE_OFFSET) {
-    int offset = patternMatcher.updateStorageOffsetGetOffset(calleeName);
-    std::string srcTypeStr = patternMatcher.updateStorageOffsetGetFromType(calleeName);
-    std::string destTypeStr = patternMatcher.updateStorageOffsetGetToType(calleeName);
-    rewriteStorageOffsetUpdateIntrinsic(callInst, offset, srcTypeStr, destTypeStr);
+    auto res = patternMatcher.parseUpdateStorageOffset(calleeName);
+    rewriteStorageOffsetUpdateIntrinsic(callInst, res.offset, res.fromType, res.toType);
   } else if (updateType == YUL_INTRINSIC_ID::UPDATE_STORAGE_DYNAMIC) {
-    std::string srcTypeStr = patternMatcher.updateStorageDynamicGetFromType(calleeName);
-    std::string destTypeStr = patternMatcher.updateStorageDynamicGetToType(calleeName);
-    rewriteStorageDynamicUpdateIntrinsic(callInst, srcTypeStr, destTypeStr);
+    auto res = patternMatcher.parseUpdateStorageDynamic(calleeName);
+    rewriteStorageDynamicUpdateIntrinsic(callInst, res.fromType, res.toType);
   } else {
     // @todo raise runtime error
     assert(false && "update_storage_value did not match any regex");


### PR DESCRIPTION
Moved the regex pattern matching behaviour in its own class and added helper functions to get various components of the name. These helpers raise runtime errors on failure there for are moving the separating concerns of heuristic pattern matching on names. 