### PR TITLE
Set LLVM build flags directly in target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,12 +44,8 @@ if(Y2L_ENABLE_LLVM)
     set_property(TARGET ${_llvm_comp} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${LLVM_INCLUDE_DIRS})
   endforeach()
 
-  if (NOT LLVM_ENABLE_RTTI)
-    add_compile_options(-fno-rtti)
-  endif()
-
-  separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
-  add_definitions(${LLVM_DEFINITIONS_LIST})
+  # Don't set global LLVM compile flags here. That should be done by calling
+  # llvm_update_compile_flags() on every target that depends on LLVM.
 else()
   message(STATUS "LLVM target support disabled")
 endif()

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ poetry install --extras dev
 #### C++ component
 
 Dependencies:
-* LLVM 13 built with `LLVM_ENABLE_RTTI=on`
+* LLVM 13
 * nlohmann json
 * (Optional) GoogleTest (for unit tests)
 

--- a/lib/libyul2llvm/CMakeLists.txt
+++ b/lib/libyul2llvm/CMakeLists.txt
@@ -9,5 +9,7 @@ target_link_libraries(libyul2llvm PUBLIC
   LLVMCore
   LLVMPasses
 )
+llvm_update_compile_flags(libyul2llvm)
+target_compile_options(libyul2llvm PRIVATE -fexceptions)  # needed by gmpcxx
 
 add_subdirectory(YulASTVisitor)

--- a/lib/yul2llvm_cpp/CMakeLists.txt
+++ b/lib/yul2llvm_cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_executable(yul2llvm_cpp yul2llvm_cpp.cpp)
 target_link_libraries(yul2llvm_cpp PRIVATE LLVMSupport libyul2llvm)
 set_target_properties(yul2llvm_cpp PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+llvm_update_compile_flags(yul2llvm_cpp)
+target_compile_options(yul2llvm_cpp PRIVATE -fexceptions)  # needed by gmpcxx
 
 install(TARGETS yul2llvm_cpp
   EXPORT Yul2LLVMTargets


### PR DESCRIPTION
This uses the llvm_update_compile_flags() from AddLLVM.cmake, which sets all relevant build flags from the exported LLVM CMake configuration.