### PR TITLE
VAN-116 fixes alignment bug for testcase struct-storage-return.sol

### DIFF
--- a/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
+++ b/lib/libyul2llvm/YulASTVisitor/IntrinsicRewriter.cpp
@@ -518,10 +518,21 @@ void YulIntrinsicHelper::rewriteConvertStorageToMemoryPtr(
   auto sizeArray = visitor.getLLVMValueVector({structType.size});
   llvm::Value *newLocation = tmpBuilder.CreateCall(
       visitor.getAllocateMemoryFunction(), sizeArray, "new" + structType.name);
-  auto align = visitor.getModule().getDataLayout().getABITypeAlign(
+  auto destalign = visitor.getModule().getDataLayout().getABITypeAlign(
       newLocation->getType());
-  tmpBuilder.CreateMemCpy(newLocation, align, callInst->getArgOperand(1), align,
-                          sizeArray[0]);
+  llvm::Value *src = callInst->getArgOperand(1);
+  llvm::Type *int8PtrType =
+      llvm::Type::getInt8PtrTy(visitor.getContext(), STORAGE_ADDR_SPACE);
+  if (!src->getType()->isPointerTy()) {
+    src = tmpBuilder.CreateIntToPtr(src, int8PtrType, src->getName() + "_ptr");
+  } else if (src->getType()->getIntegerBitWidth() != 8) {
+    src = tmpBuilder.CreatePointerBitCastOrAddrSpaceCast(
+        src, int8PtrType, src->getName() + "_ptr");
+  }
+
+  auto srcAlign =
+      visitor.getModule().getDataLayout().getABITypeAlign(src->getType());
+  tmpBuilder.CreateMemCpy(newLocation, destalign, src, srcAlign, sizeArray[0]);
   llvm::Value *castedNewLocation = tmpBuilder.CreatePtrToInt(
       newLocation, visitor.getDefaultType(), newLocation->getName() + "i256");
   llvm::ReplaceInstWithValue(instList, callInstIt, castedNewLocation);

--- a/tests/e2e/feature/structs/struct-storage-return.sol
+++ b/tests/e2e/feature/structs/struct-storage-return.sol
@@ -23,6 +23,6 @@ contract StructTest {
 
 //CHECK: define i256 @fun_readStruct_{{.*}}(i256 addrspace(1)* %__self) {
 //CHECK:   %{{newSt}} = call i8 addrspace(2)* @alloc_mem(i32 10)
-//CHECK:   call void @llvm.memcpy.p2i8.p256i8.i32(i8 addrspace(2)* align 8 %{{.*}}, i8 addrspace(256)* align 8 null, i32 10, i1 false)
+//CHECK:   call void @llvm.memcpy.p2i8.p1i8.i32(i8 addrspace(2)* align 8 %{{.*}}, i8 addrspace(1)* align 8 null, i32 10, i1 false)
 //CHECK:   %{{.*}} = ptrtoint i8 addrspace(2)* %{{.*}} to i256
 //CHECK:   ret i256 %{{.*}}


### PR DESCRIPTION
Casted source pointer to i8* in memcpy emitted during translation of convert_t_struct_*_storage_to_t_struct_*_memory_ptr